### PR TITLE
Fix QmlJuliaExamples clone branch

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ withenv("JULIA_LOAD_PATH" => nothing, "JULIA_GR_PROVIDER" => "BinaryBuilder") do
   mktempdir() do tmpd
     cd(tmpd) do
       examplesdir = mkdir("QmlJuliaExamples")
-      LibGit2.clone("https://github.com/barche/QmlJuliaExamples.git", examplesdir; branch="qt6")
+      LibGit2.clone("https://github.com/barche/QmlJuliaExamples.git", examplesdir)
       cd(examplesdir) do
         for d in ["basic", "images", "opengl", "plots"]
           cd(d) do 


### PR DESCRIPTION
Try to fix the following issue during `test QML`:
```
ERROR: LoadError: GitError(Code:ENOTFOUND, Class:Reference, reference 'refs/remotes/origin/qt6' not found)
Stacktrace:
  [1] macro expansion
    @ ~/.julia/juliaup/julia-1.9.3+0.x64.apple.darwin14/share/julia/stdlib/v1.9/LibGit2/src/error.jl:111 [inlined]
  [2] clone(repo_url::String, repo_path::String, clone_opts::LibGit2.CloneOptions)
    @ LibGit2 ~/.julia/juliaup/julia-1.9.3+0.x64.apple.darwin14/share/julia/stdlib/v1.9/LibGit2/src/repository.jl:459
  [3] clone(repo_url::String, repo_path::String; branch::String, isbare::Bool, remote_cb::Ptr{Nothing}, credentials::Nothing, callbacks::Dict{Symbol, Tuple{Ptr{Nothing}, Any}})
    @ LibGit2 ~/.julia/juliaup/julia-1.9.3+0.x64.apple.darwin14/share/julia/stdlib/v1.9/LibGit2/src/LibGit2.jl:583
  [4] clone
    @ ~/.julia/juliaup/julia-1.9.3+0.x64.apple.darwin14/share/julia/stdlib/v1.9/LibGit2/src/LibGit2.jl:556 [inlined]
  [5] #20
    @ ~/.julia/packages/QML/UTMZh/test/runtests.jl:28 [inlined]
  [6] cd(f::var"#20#27", dir::String)
    @ Base.Filesystem ./file.jl:112
  [7] #19
    @ ~/.julia/packages/QML/UTMZh/test/runtests.jl:26 [inlined]
  [8] mktempdir(fn::var"#19#26", parent::String; prefix::String)
    @ Base.Filesystem ./file.jl:760
  [9] mktempdir (repeats 2 times)
    @ ./file.jl:756 [inlined]
 [10] #18
    @ ~/.julia/packages/QML/UTMZh/test/runtests.jl:25 [inlined]
 [11] withenv(::var"#18#25", ::Pair{String, Nothing}, ::Vararg{Pair{String}})
    @ Base ./env.jl:197
 [12] top-level scope
    @ ~/.julia/packages/QML/UTMZh/test/runtests.jl:24
 [13] include(fname::String)
    @ Base.MainInclude ./client.jl:478
 [14] top-level scope
    @ none:6
in expression starting at /Users/christophemeyer/.julia/packages/QML/UTMZh/test/runtests.jl:24
ERROR: Package QML errored during testing
```