### PR TITLE
Fix building of the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ include("gui.jl") # Or any of the files in the directory
 ### Loading a QML file
 We support three methods of loading a QML file: `QQmlApplicationEngine`, `QQuickView` and `QQmlComponent`. These behave equivalently to the corresponding Qt classes.
 #### QQmlApplicationEngine
-The easiest way to run the QML file `main.qml` from the current directory is using the `load` function, which will create and return a `QQmlApplicationEngine` and load the supplied QML file:
+The easiest way to run the QML file `main.qml` from the current directory is using the `loadqml` function, which will create and return a `QQmlApplicationEngine` and load the supplied QML file:
 ```julia
 using QML
-load("main.qml")
+loadqml("main.qml")
 exec()
 ```
 
@@ -139,14 +139,14 @@ The value of a property can be queried from Julia like this:
 @test propmap["a"] == 1
 ```
 
-To pass these properties to the QML side, the property map can be the second argument to `load`:
+To pass these properties to the QML side, the property map can be the second argument to `loadqml`:
 ```julia
-load(qml_file, propmap)
+loadqml(qml_file, propmap)
 ```
 
 There is also a shorthand notation using keywords:
 ```julia
-load(qml_file, a=1, b=2)
+loadqml(qml_file, a=1, b=2)
 ```
 This will create context properties `a` and `b`, initialized to `1` and `2`.
 
@@ -164,7 +164,7 @@ on(output) do x
   println("Output changed to ", x)
 end
 
-load(qml_file, input=input, output=output)
+loadqml(qml_file, input=input, output=output)
 exec_async() # run from REPL for async execution
 ```
 
@@ -249,7 +249,7 @@ adds the role named `myrole` to `array_model`, using the function `myrole` to ac
 
 To use the model from QML, it can be exposed as a context attribute, e.g:
 ```julia
-load(qml_file, array_model=array_model)
+loadqml(qml_file, array_model=array_model)
 ```
 
 And then in QML:
@@ -300,7 +300,7 @@ end
 
 @qmlfunction counter_slot
 
-load(qml_file, timer=QTimer(), bg_counter=bg_counter)
+loadqml(qml_file, timer=QTimer(), bg_counter=bg_counter)
 ```
 
 Use in QML like this:
@@ -411,9 +411,9 @@ function paint_circle(buffer)
     end
  end
 
- load(qmlfile,
-      #...
-      paint_cfunction = CxxWrap.@safe_cfunction(paint_circle, Cvoid, (Array{UInt32,1}, Int32, Int32))
+ loadqml(qmlfile,
+         #...
+         paint_cfunction = CxxWrap.@safe_cfunction(paint_circle, Cvoid, (Array{UInt32,1}, Int32, Int32))
  )
 ```
 Note that the canvas buffer is allocated (and freed) in the C++ code.  A new unitialized buffer is allocated for each frame (this could change).

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,7 +6,7 @@ We support three methods of loading a QML file: [`QML.QQmlApplicationEngine`](@r
 [`QML.QQuickView`](@ref) and [`QQmlComponent`](@ref). These behave equivalently to the
 corresponding Qt classes. They have different advantages:
 
-- You can simply [`load`](@ref) a QML file as a [`QML.QQmlApplicationEngine`](@ref).
+- You can simply load a QML file using the [`loadqml`](@ref) function as a [`QML.QQmlApplicationEngine`](@ref).
 - [`QML.QQuickView`](@ref) creates a window, so it's not necessary to wrap the QML in `ApplicationWindow`.
 - You can run QML code contained in a string with [`QQmlComponent`](@ref).
 
@@ -19,9 +19,9 @@ Since QML.jl version 0.2, only the `QtDeclarative` package is installed by defau
 Interaction with Julia happens through the following mechanisms:
 
 * Call Julia functions from QML, e.g. with [`@qmlfunction`](@ref).
-* Read and set context properties from Julia and QML, e.g. with keywords to [`load`](@ref) or [`set_context_property`](@ref).
+* Read and set context properties from Julia and QML, e.g. with keywords to [`loadqml`](@ref) or [`set_context_property`](@ref).
 * Emit signals from Julia to QML, e.g. with [`@emit`](@ref).
-* Use data models, e.g. [`ListModel`](@ref) or [`JuliaPropertyMap`](@ref).
+* Use data models, e.g. [`JuliaItemModel`](@ref) or [`JuliaPropertyMap`](@ref).
 
 Note that Julia slots appear missing, but they are not needed since it is possible to directly connect a Julia function to a QML signal in the QML code, e.g. with [`QTimer`](@ref).
 

--- a/src/docs.jl
+++ b/src/docs.jl
@@ -167,9 +167,9 @@ julia> mktempdir() do folder
 JuliaDisplay
 
 """
-Module for building [Qt5 QML](http://doc.qt.io/qt-5/qtqml-index.html) graphical user interfaces for Julia programs.
+Module for building [Qt6 QML](http://doc.qt.io/qt-6/qtqml-index.html) graphical user interfaces for Julia programs.
 Types starting with `Q` are equivalent of their Qt C++ counterpart, so, unless otherwise noted, they have no Julia docstring and we refer to
-the [Qt documentation](http://doc.qt.io/qt-5/qtqml-index.html) for details instead.
+the [Qt documentation](http://doc.qt.io/qt-6/qtqml-index.html) for details instead.
 """
 QML
 
@@ -201,7 +201,7 @@ QByteArray
     struct QQmlApplicationEngine
 
 One of 3 ways to interact with QML (the others being [`QQuickView`](@ref) and
-[`QQmlComponent`](@ref). You can load a QML file to create an engine with [`load`](@ref).
+[`QQmlComponent`](@ref). You can load a QML file to create an engine with [`load`].
 Use [`exec`](@ref) to execute a file after it's been loaded.
 
 The lifetime of the `QQmlApplicationEngine` is managed from C++ and it gets cleaned up when


### PR DESCRIPTION
- rename `load` to `loadqml`
- rename `ListModel` to `JuliaItemModel`
- update links to QT5 to QT6