### PR TITLE
Update default example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Pkg.activate(".")
 Pkg.instantiate()
 
 readdir() # Print list of example files
-include("gui.jl") # Or any of the files in the directory
+include("filedialog.jl") # Or any of the files in the directory
 ```
 
 


### PR DESCRIPTION
At least with my qt theme - I work on a KDE desktop - does the example from the README, that is running when the user follows its instructions, show up like this:

![Screenshot_20240421_142536](https://github.com/JuliaGraphics/QML.jl/assets/6344099/b0143745-2a5b-4090-8b6d-a23c7a9ff92b)


I do not know, if this is due to the Qt6 change, but another example runs just fine: 

![Screenshot_20240421_142610](https://github.com/JuliaGraphics/QML.jl/assets/6344099/daf31321-e941-435d-a3d9-a3a598bb756e)

Obviously, this warrants an investigation. But for now, I suggest to at least replace the default example. This PR does this. 🙂 