### PR TITLE
Fix exec_async on Julia 1.11

### DIFF
--- a/src/QML.jl
+++ b/src/QML.jl
@@ -623,10 +623,13 @@ end
 
 include("itemmodel.jl")
 
-global _async_timer
-
 function exec_async()
-  newrepl = @async Base.run_main_repl(true,true,true,true,true)
+  if VERSION >= v"1.11-"
+    newrepl = @async Base.run_main_repl(true,true,:yes,true,true)
+  else
+    newrepl = @async Base.run_main_repl(true,true,true,true,true)
+  end
+
   while !istaskdone(newrepl)
       for (updater, x) in _queued_properties
         updater.propertymap[updater.key] = x


### PR DESCRIPTION
`exec_async` uses the private Base function `run_main_repl`, but in Julia 1.11, the arguments changed, which casued `exec_async` to fail silently. This fixes the issue by checking the Julia version and using the appropriate arguments.

Also removed unused global `_async_timer` (it was used for an earlier implementation of `exec_async`, but isn't used anymore).